### PR TITLE
fix for #11

### DIFF
--- a/hana/hana_integration_test.go
+++ b/hana/hana_integration_test.go
@@ -53,7 +53,7 @@ func TestHANAPublish(t *testing.T) {
 		config["database"] = ctypes.ConfigValueStr{Value: "SNAP_TEST"}
 		config["host"] = ctypes.ConfigValueStr{Value: "localhost"}
 		config["port"] = ctypes.ConfigValueStr{Value: "1433"}
-		config["table name"] = ctypes.ConfigValueStr{Value: "info"}
+		config["tablename"] = ctypes.ConfigValueStr{Value: "info"}
 		sp := NewHANAPublisher()
 		cp, _ := sp.GetConfigPolicy()
 		cfg, _ := cp.Get([]string{""}).Process(config)


### PR DESCRIPTION
Fixes #11 
Summary of changes:
-changed one line which caused bug

Testing done:
-unit tests

Before: 
```
=== RUN   TestHANAPublish

  TestHANAPublish 🔥


Errors:

  * /home/daria/work/snap/src/github.com/intelsdi-x/snap-plugin-publisher-hana/hana/hana_integration_test.go 
  Line 62: - runtime error: invalid memory address or nil pointer dereference 
  goroutine 18 [running]:
  panic(0x90d740, 0xc820010130)
  	/home/daria/work/snap/go/src/runtime/panic.go:443 +0x4e9
  github.com/intelsdi-x/snap-plugin-publisher-hana/hana.TestHANAPublish.func1()
  	/home/daria/work/snap/src/github.com/intelsdi-x/snap-plugin-publisher-hana/hana/hana_integration_test.go:62 +0x66a
  github.com/jtolds/gls._m(0x0, 0xc820144840)
  	/home/daria/work/snap/src/github.com/jtolds/gls/stack_tags.go:39 +0x2b
  github.com/jtolds/gls.markS(0x0, 0xc820144840)
  	/home/daria/work/snap/src/github.com/jtolds/gls/stack_tags.go:16 +0x2b
  github.com/jtolds/gls.addStackTag(0x0, 0xc820144840)
  	/home/daria/work/snap/src/github.com/jtolds/gls/stack_tags.go:13 +0x37
  github.com/jtolds/gls.(*ContextManager).SetValues(0xc820144040, 0xc82013cde0, 0xc820144840)
  	/home/daria/work/snap/src/github.com/jtolds/gls/context.go:92 +0x4b3
  github.com/intelsdi-x/snap-plugin-publisher-hana/hana.TestHANAPublish(0xc82014a120)
  	/home/daria/work/snap/src/github.com/intelsdi-x/snap-plugin-publisher-hana/hana/hana_integration_test.go:71 +0x11ca
  testing.tRunner(0xc82014a120, 0xc750e0)
  	/home/daria/work/snap/go/src/testing/testing.go:473 +0x98
  created by testing.RunTests
  	/home/daria/work/snap/go/src/testing/testing.go:582 +0x892
  
  goroutine 1 [chan receive]:
  testing.RunTests(0xab3e78, 0xc750e0, 0x1, 0x1, 0xc9e901)
  	/home/daria/work/snap/go/src/testing/testing.go:583 +0x8d2
  testing.(*M).Run(0xc820129ee8, 0x0)
  	/home/daria/work/snap/go/src/testing/testing.go:515 +0x81
  main.main()
  	github.com/intelsdi-x/snap-plugin-publisher-hana/hana/_test/_testmain.go:54 +0x117
  
  goroutine 17 [syscall, locked to thread]:
  runtime.goexit()
  	/home/daria/work/snap/go/src/runtime/asm_amd64.s:1998 +0x1
```
After (without previous error):
```
So publishing metrics should not result in an error ✘


Failures:

  * /home/daria/work/snap/src/github.com/intelsdi-x/snap-plugin-publisher-hana/hana/hana_integration_test.go 
  Line 66:
  Expected: nil
  Actual:   'dial tcp 127.0.0.1:1433: getsockopt: connection refused'


2 total assertions
```
That happens just because i don't have any HANA agent so I can't verify this.Test should work after this fix. 

